### PR TITLE
Restrict the supported NodeJS version to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": ">=16.0.0"
+    "node": "^18.0.0"
   },
   "devDependencies": {
     "@types/webpack": "^5.28.0",


### PR DESCRIPTION
Node 19 is not supported by tree-sitter yet, and that is a dependency of @fastly/js-compute. Until tree-sitter works on Node 19, we should not list Node 19 as supported.