### PR TITLE
Use @fastly/cli in the starter kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ This is the entry point of the application, an event-listener is attached to the
 
 This is where the majority of our application code lives. A single async function is exported named `app`, which is the function that recieves the incoming `FetchEvent` and returns a `Response` instance, which will be sent to the user-agent.
 
+## Running the application
+
+To create an application using this starter kit, create a new directory for your application and switch to it, and then type the following command:
+
+```shell
+npm create @fastly/compute@latest -- --language=typescript --starter-kit=kv-store
+```
+
+To build and run your new application in the local development environment, type the following command:
+
+```shell
+npm run start
+```
+
 ## Deploying the project to Fastly
 
 Note that Fastly Services have to have unique names within a Fastly Account.
@@ -21,26 +35,26 @@ Note that Fastly Services have to have unique names within a Fastly Account.
 To create and deploy to a new Fastly Service run the command and follow the instructions:
 
 ```shell
-fastly compute publish
+npm run deploy
 ```
 
 That is it, we now have a Fastly Service, a Fastly KV Store and have them linked together!
 
 You can view real-time logs for the Fastly Service by running:
 ```shell
-fastly log-tail
+npx fastly log-tail
 ```
 
 ## Adding entries to the KV Store
 
 It is possible to add key-value pairs to an KV Store using the Fastly CLI like so:
 ```shell
-fastly kv-store-entry create --store-id=$FASTLY_KV_STORE_ID --key-name=$KEY --value=$VALUE
+npx fastly kv-store-entry create --store-id=$FASTLY_KV_STORE_ID --key-name=$KEY --value=$VALUE
 ```
 
 For example, here is how you could add to the KV Store named `my-store` a key named `readme` whose value is the contents of `README.md`:
 ```shell
-fastly kv-store-entry create --store-id="$(fastly kv-store list --json | jq -r '.Data[]|select(.Name=="my-store").ID')" --key-name="readme" --value="$(cat README.md)"
+npx fastly kv-store-entry create --store-id="$(npx fastly kv-store list --json | jq -r '.Data[]|select(.Name=="my-store").ID')" --key-name="readme" --value="$(cat README.md)"
 ```
 
 ## Security issues

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": "^18.0.0"
   },
   "devDependencies": {
+    "@fastly/cli": "^10.14.0",
     "typescript": "^5.0.0"
   },
   "dependencies": {
@@ -15,6 +16,7 @@
   "scripts": {
     "prebuild": "tsc",
     "build": "js-compute-runtime build/index.js bin/main.wasm",
-    "deploy": "npm run build && fastly compute deploy"
+    "start": "fastly compute serve",
+    "deploy": "fastly compute publish"
   }
 }


### PR DESCRIPTION
This PR makes changes:

* Changes to **package.json** to enable usage without a global installation of the Fastly CLI:
   * Adds `@fastly/cli` to `devDependencies` so that it's available when using the starter kit, as a tool used to build and run or publish the application.
   * Makes sure that `scripts` contains `start` and `deploy` scripts as applicable.

* Adds instructions to the README describing how to initialize an application using the starter kit, as well as how to run it locally or publish it to a Fastly service, as applicable.

* Adds `post_init` script to run `npm install` if it was not present.